### PR TITLE
Update Google API key

### DIFF
--- a/BeFake/config.py
+++ b/BeFake/config.py
@@ -33,7 +33,7 @@ CONFIG = {
         },
     },
     "google": {
-        "api-key": "AIzaSyDwjfEeparokD7sXPVQli9NsTuhT6fJ6iA",
+        "api-key": "AIzaSyCgNTZt6gzPMh-2voYXOvrt_UR_gpGl83Q",
         "appToken": "54F80A258C35A916B38A3AD83CA5DDD48A44BFE2461F90831E0F97EBA4BB2EC7",
     },
 }


### PR DESCRIPTION
Current API key yields the following response from the identitytoolkit:
```
{
  "error": {
    "code": 400,
    "message": "API key expired. Please renew the API key.",
    "errors": [
      {
        "message": "API key expired. Please renew the API key.",
        "domain": "global",
        "reason": "badRequest"
      }
    ],
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "API_KEY_INVALID",
        "domain": "googleapis.com",
        "metadata": {
          "service": "identitytoolkit.googleapis.com"
        }
      }
    ]
  }
}
```
Changing it to the new value (found here https://github.com/s-alad/toofake/blob/main/client/utils/constants.ts) allows logging in again.